### PR TITLE
slab.h, structure name and Makefile's clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ default:
 endif
 
 clean:
-	rm -rf scull_pipe.ko devices.o fops.o .fops.cmd scull_pipe.mod.c scull_pipe.mod.o main.o modules.order Module.symvers scull_pipe.ko.unsigned .devices.o.cmd .fops.o.d .scull_pipe.ko.cmd .scull_pipe.ko.unsigned.cmd .main.mod.o.cmd .main.o.cmd .main.o.d .fops.o.cmd .tmp_versions/ .scull_pipe.mod.o.cmd .scull_pipe.o.cmd scull_pipe.o
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean

--- a/fops.c
+++ b/fops.c
@@ -8,7 +8,7 @@
 #include <linux/sched.h>
 #include <linux/ioctl.h>
 #include <linux/poll.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include "scull.h"
 
 static int spacefree(struct scull_pipe *dev){
@@ -264,7 +264,7 @@ int scull_p_ioctl(struct file *filp, unsigned int cmd, unsigned long arg){
 }
 #endif
 
-static unsigned int scull_p_poll(struct file *filp, struct poll_table *wait)
+static unsigned int scull_p_poll(struct file *filp, struct poll_table_struct *wait)
 {
 	struct scull_pipe *dev = filp->private_data;
 	unsigned int mask = 0;

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h> /* Parameters definition */
+#include <linux/slab.h> /* kmalloc, kfree */ 
 #include <linux/kdev_t.h>
 #include <linux/proc_fs.h>
 #include <linux/semaphore.h>


### PR DESCRIPTION
I've added `slab.h` which is required for `kmalloc` and `kfree`. I've also changed the `poll_table` struct name from `poll_table` to `poll_table_struct` to make it compatible with today. I also think that `#include <linux/uaccess.h>` is preferable instead of `#include <asm/uaccess.h>`

I also changed the Makefile `clean` section, using the kernel build system to clean the module's files is more logical